### PR TITLE
ENH: Initiate default community files in the magic ``.github`` repo

### DIFF
--- a/.github/CODE_OF_CONDUCT.md
+++ b/.github/CODE_OF_CONDUCT.md
@@ -1,0 +1,84 @@
+# Contributor Covenant Code of Conduct
+
+## Our Pledge
+
+We as members, contributors, and leaders pledge to make participation in our community a harassment-free experience for everyone, regardless of age, body size, visible or invisible disability, ethnicity, sex characteristics, gender identity and expression, level of experience, education, socio-economic status, nationality, personal appearance, race, religion, or sexual identity and orientation.
+
+We pledge to act and interact in ways that contribute to an open, welcoming, diverse, inclusive, and healthy community.
+
+## Our Standards
+
+Examples of behavior that contributes to a positive environment for our community include:
+
+* Demonstrating empathy and kindness toward other people
+* Being respectful of differing opinions, viewpoints, and experiences
+* Giving and gracefully accepting constructive feedback
+* Accepting responsibility and apologizing to those affected by our mistakes, and learning from the experience
+* Focusing on what is best not just for us as individuals, but for the overall community
+
+Examples of unacceptable behavior include:
+
+* The use of sexualized language or imagery, and sexual attention or
+  advances of any kind
+* Trolling, insulting or derogatory comments, and personal or political attacks
+* Public or private harassment
+* Publishing others' private information, such as a physical or email
+  address, without their explicit permission
+* Other conduct which could reasonably be considered inappropriate in a
+  professional setting
+
+## Enforcement Responsibilities
+
+Community leaders are responsible for clarifying and enforcing our standards of acceptable behavior and will take appropriate and fair corrective action in response to any behavior that they deem inappropriate, threatening, offensive, or harmful.
+
+Community leaders have the right and responsibility to remove, edit, or reject comments, commits, code, wiki edits, issues, and other contributions that are not aligned to this Code of Conduct, and will communicate reasons for moderation decisions when appropriate.
+
+## Scope
+
+This Code of Conduct applies within all community spaces, and also applies when an individual is officially representing the community in public spaces. Examples of representing our community include using an official e-mail address, posting via an official social media account, or acting as an appointed representative at an online or offline event.
+
+## Enforcement
+
+Instances of abusive, harassing, or otherwise unacceptable behavior may be reported to the community leaders responsible for enforcement as set forth in the Organization's `CHARTER.md` file. All complaints will be reviewed and investigated promptly and fairly.
+
+All community leaders are obligated to respect the privacy and security of the reporter of any incident.
+
+## Enforcement Guidelines
+
+Community leaders will follow these Community Impact Guidelines in determining the consequences for any action they deem in violation of this Code of Conduct:
+
+### 1. Correction
+
+**Community Impact**: Use of inappropriate language or other behavior deemed unprofessional or unwelcome in the community.
+
+**Consequence**: A private, written warning from community leaders, providing clarity around the nature of the violation and an explanation of why the behavior was inappropriate. A public apology may be requested.
+
+### 2. Warning
+
+**Community Impact**: A violation through a single incident or series of actions.
+
+**Consequence**: A warning with consequences for continued behavior. No interaction with the people involved, including unsolicited interaction with those enforcing the Code of Conduct, for a specified period of time. This includes avoiding interactions in community spaces as well as external channels like social media. Violating these terms may lead to a temporary or permanent ban.
+
+### 3. Temporary Ban
+
+**Community Impact**: A serious violation of community standards, including sustained inappropriate behavior.
+
+**Consequence**: A temporary ban from any sort of interaction or public communication with the community for a specified period of time. No public or private interaction with the people involved, including unsolicited interaction with those enforcing the Code of Conduct, is allowed during this period. Violating these terms may lead to a permanent ban.
+
+### 4. Permanent Ban
+
+**Community Impact**: Demonstrating a pattern of violation of community standards, including sustained inappropriate behavior,  harassment of an individual, or aggression toward or disparagement of classes of individuals.
+
+**Consequence**: A permanent ban from any sort of public interaction within the project community.
+
+## Attribution
+
+This Code of Conduct is adapted from the [Contributor Covenant][homepage], version 2.0,
+available at https://www.contributor-covenant.org/version/2/0/code_of_conduct.html.
+
+Community Impact Guidelines were inspired by [Mozilla's code of conduct enforcement ladder](https://github.com/mozilla/diversity).
+
+[homepage]: https://www.contributor-covenant.org
+
+For answers to common questions about this code of conduct, see the FAQ at
+https://www.contributor-covenant.org/faq. Translations are available at https://www.contributor-covenant.org/translations.

--- a/.github/CONTRIBUTING.md
+++ b/.github/CONTRIBUTING.md
@@ -1,0 +1,390 @@
+# Contributing Guidelines
+
+Welcome to the *NiPreps* project!
+We're excited you're here and want to contribute.
+
+!!! info "Imposter's syndrome disclaimer"
+    **Imposter's syndrome disclaimer**[^1]: We want your help. No, really.
+
+    There may be a little voice inside your head that is telling you that
+    you're not ready to be an open-source contributor; that your skills
+    aren't nearly good enough to contribute. What could you possibly offer a
+    project like this one?
+
+    We assure you - the little voice in your head is wrong. If you can
+    write code at all, you can contribute code to open-source. Contributing
+    to open-source projects is a fantastic way to advance one's coding
+    skills. Writing perfect code isn't the measure of a good developer (that
+    would disqualify all of us!); it's trying to create something, making
+    mistakes, and learning from those mistakes. That's how we all improve,
+    and we are happy to help others learn.
+
+    Being an open-source contributor doesn't just mean writing code, either.
+    You can help out by writing documentation, tests, or even giving
+    feedback about the project (and yes - that includes giving feedback
+    about the contribution process). Some of these contributions may be the
+    most valuable to the project as a whole, because you're coming to the
+    project with fresh eyes, so you can see the errors and assumptions that
+    seasoned contributors have glossed over.
+
+## Driving principles
+
+*NiPreps* are built around three overarching principles:
+
+1. **Robustness** - The pipeline adapts the preprocessing steps depending on
+   the input dataset and should provide results as good as possible
+   independently of scanner make, scanning parameters or presence of additional
+   correction scans (such as fieldmaps).
+1. **Ease of use** - Thanks to dependence on the BIDS standard, manual
+   parameter input is reduced to a minimum, allowing the pipeline to run in an
+   automatic fashion.
+1. **"Glass box"** philosophy - Automation should not mean that one should not
+   visually inspect the results or understand the methods.
+   Thus, *NiPreps* provides visual reports for each subject, detailing the
+   accuracy of the most important processing steps.
+   This, combined with the documentation, can help researchers to understand
+   the process and decide which subjects should be kept for the group level
+   analysis.
+
+These principles distill some design and organizational foundations:
+
+  1. *NiPreps* only and fully support BIDS and BIDS-Derivatives for the input and output data.
+  1. *NiPreps* are packaged as a fully-compliant [BIDS-Apps](../apps/framework.md), not just in its user interface, but also in the continuous integration, testing, and delivery.
+  1. The scope of *NiPreps* is strictly limited to preprocessing tasks.
+  1. *NiPreps* are agnostic to subsequent analysis, i.e., any software supporting BIDS-Derivatives for its inputs should be amenable to analyze data preprocessed with them.
+  1. *NiPreps* are thoroughly and transparently documented (including the generation of individual, visual reports with a consistent format that serve as scaffolds for understanding the underpinnings and design decisions).
+  1. *NiPreps* are community-driven, and contributors (in any sense) always [get credited](#recognizing-contributions) with authorship within relevant publications.
+  1. *NiPreps* are modular, reliant on widely-used tools such as *AFNI*, *ANTs*, *FreeSurfer*, *FSL*, *NiLearn*, or *DIPY* [7-12] and extensible via plug-ins.
+
+## Practical guide to submitting your contribution
+
+These guidelines are designed to make it as easy as possible to get involved.
+If you have any questions that aren't discussed below,
+please let us know by opening an [issue][link_issues]!
+
+Before you start, you'll need to set up a free [GitHub][link_github] account and sign in.
+Here are some [instructions][link_signupinstructions].
+
+Already know what you're looking for in this guide? Jump to the following sections:
+
+* [Joining the conversation](#joining-the-conversation)
+* [Contributing through Github](#contributing-through-github)
+* [Understanding issues](#understanding-issues)
+* [Making a change](#making-a-change)
+* [Structuring contributions](#NiPreps-coding-style-guide)
+* [Licensing](#licensing)
+* [Recognizing contributors](#recognizing-contributions)
+
+## Joining the conversation
+
+*NiPreps* is maintained by a growing group of enthusiastic developers&mdash;
+and we're excited to have you join!
+Most of our discussions will take place on open [issues][link_issues].
+
+We also encourage users to report any difficulties they encounter on [NeuroStars][link_neurostars],
+a community platform for discussing neuroimaging.
+
+We actively monitor both spaces and look forward to hearing from you in either venue!
+
+## Contributing through GitHub
+
+[git][link_git] is a really useful tool for version control.
+[GitHub][link_github] sits on top of git and supports collaborative and distributed working.
+
+If you're not yet familiar with `git`, there are lots of great resources to help you *git* started!
+Some of our favorites include the [git Handbook][link_handbook] and
+the [Software Carpentry introduction to git][link_swc_intro].
+
+On GitHub, You'll use [Markdown][markdown] to chat in issues and pull requests.
+You can think of Markdown as a few little symbols around your text that will allow GitHub
+to render the text with a little bit of formatting.
+For example, you could write words as bold (`**bold**`), or in italics (`*italics*`),
+or as a [link][rick_roll] (`[link](https://youtu.be/dQw4w9WgXcQ)`) to another webpage.
+
+GitHub has a really helpful page for getting started with
+[writing and formatting Markdown on GitHub][writing_formatting_github].
+
+## Understanding issues
+
+Every project on GitHub uses [issues][link_issues] slightly differently.
+
+The following outlines how the *NiPreps* developers think about these tools.
+
+* **Issues** are individual pieces of work that need to be completed to move the project forward.
+A general guideline: if you find yourself tempted to write a great big issue that
+is difficult to describe as one unit of work, please consider splitting it into two or more issues.
+
+    Issues are assigned [labels](#issue-labels) which explain how they relate to the overall project's
+    goals and immediate next steps.
+
+### Issue Labels
+
+The current list of issue labels are [here][link_labels] and include:
+
+* [![Good first issue](https://img.shields.io/github/labels/nipreps/fmriprep/good%20first%20issue)][link_firstissue] *These issues contain a task that is amenable to new contributors because it doesn't entail a steep learning curve.*
+
+    If you feel that you can contribute to one of these issues,
+    we especially encourage you to do so!
+
+* [![Bug](https://img.shields.io/github/labels/nipreps/fmriprep/bug)][link_bugs] *These issues point to problems in the project.*
+
+    If you find new a bug, please give as much detail as possible in your issue,
+    including steps to recreate the error.
+    If you experience the same bug as one already listed,
+    please add any additional information that you have as a comment.
+
+* [![Feature](https://img.shields.io/github/labels/nipreps/fmriprep/feature)][link_enhancement] *These issues are asking for new features and improvements to be considered by the project.*
+
+    Please try to make sure that your requested feature is distinct from any others
+    that have already been requested or implemented.
+    If you find one that's similar but there are subtle differences,
+    please reference the other request in your issue.
+
+In order to define priorities and directions in the development roadmap,
+we have two sets of special labels:
+
+| Label                                                                                           | Description                                                                                           |
+|--------------------------------------------------------------------------------------------|-------------------------------------------------------------------------------------------|
+| ![GitHub labels](https://img.shields.io/github/labels/nipreps/fmriprep/impact%3A%20high) <br> ![GitHub labels](https://img.shields.io/github/labels/nipreps/fmriprep/impact%3A%20medium) <br> ![GitHub labels](https://img.shields.io/github/labels/nipreps/fmriprep/impact%3A%20low)    | Estimation of the downstream impact the proposed feature/bugfix will have.                |
+| ![GitHub labels](https://img.shields.io/github/labels/nipreps/fmriprep/effort%3A%20high) <br> ![GitHub labels](https://img.shields.io/github/labels/nipreps/fmriprep/effort%3A%20medium) <br> ![GitHub labels](https://img.shields.io/github/labels/nipreps/fmriprep/effort%3A%20low)    | Estimation of effort required to implement the requested feature or fix the reported bug. |
+
+One way to understand these labels is to consider how they would apply to an imaginary issue.
+For example, if -- after a release -- a bug is identified that re-introduces a previously solved issue
+(i.e., its regresses the code outputs to some undesired behavior), we might assign it the following labels:
+![GitHub labels](https://img.shields.io/github/labels/nipreps/fmriprep/bug)
+![GitHub labels](https://img.shields.io/github/labels/nipreps/fmriprep/impact%3A%20high)
+![GitHub labels](https://img.shields.io/github/labels/nipreps/fmriprep/effort%3A%20low).
+Its development priority would then be "high", since it is a low-effort, high-impact change.
+
+Long-term goals may be labelled as a combination of:
+![GitHub labels](https://img.shields.io/github/labels/nipreps/fmriprep/effort%3A%20high) and  ![GitHub labels](https://img.shields.io/github/labels/nipreps/fmriprep/impact%3A%20medium) or ![GitHub labels](https://img.shields.io/github/labels/nipreps/fmriprep/impact%3A%20high)
+since they will have a high-impact on the code-base, but require a medium or high amount of effort.
+Of note, issues with the labels:
+ ![GitHub labels](https://img.shields.io/github/labels/nipreps/fmriprep/impact%3A%20low) or ![GitHub labels](https://img.shields.io/github/labels/nipreps/fmriprep/effort%3A%20high)
+are less likely to be addressed because they are less likely to impact the code-base, or because they will require a very high activation energy to do so.
+
+## Making a change
+
+We appreciate all contributions to *NiPreps*,
+but those accepted fastest will follow a workflow similar to the following:
+
+1. **Comment on an existing issue or open a new issue referencing your addition.**<br />
+  This allows other members of the *NiPreps* development team to confirm that you aren't
+  overlapping with work that's currently underway and that everyone is on the same page
+  with the goal of the work you're going to carry out.<br />
+  [This blog][link_pushpullblog] is a nice explanation of why putting this work in up front
+  is so useful to everyone involved.
+
+1. **[Fork][link_fork] the particular *NiPrep* repository (e.g., [fMRIPrep][link_fMRIPrep])
+  with your GitHub user.**<br />
+  This is now your own unique copy of that particular *NiPreps* component.
+  Changes here won't affect anyone else's work, so it's a safe space to explore edits to the code!
+
+1. **[Clone][link_clone] your forked NiPreps repository to your machine/computer.**<br />
+  While you can edit files [directly on github][link_githubedit], sometimes the changes
+  you want to make will be complex and you will want to use a [text editor][link_texteditor]
+  that you have installed on your local machine/computer.
+  (One great text editor is [vscode][link_vscode]).<br />
+  In order to work on the code locally, you must clone your forked repository.<br />
+  To keep up with changes in the NiPreps repository,
+  add the ["upstream" NiPreps repository as a remote][link_addremote]
+  to your locally cloned repository.
+    ```Shell
+    git remote add upstream https://github.com/nipreps/fmriprep.git
+    ```
+    Make sure to [keep your fork up to date][link_updateupstreamwiki] with the upstream repository.<br />
+    For example, to update your master branch on your local cloned repository:
+      ```Shell
+      git fetch upstream
+      git checkout master
+      git merge upstream/master
+      ```
+
+1. **Create a [new branch][link_branches] to develop and maintain the proposed code changes.**<br />
+  For example:
+    ```Shell
+    git fetch upstream  # Always start with an updated upstream
+    git checkout -b fix/bug-1222 upstream/master
+    ```
+    Please consider using appropriate branch names as those listed below, and mind that some of them
+    are special (e.g., `doc/` and `docs/`):
+      * `fix/<some-identifier>`: for bugfixes
+      * `enh/<feature-name>`: for new features
+      * `doc/<some-identifier>`: for documentation improvements.
+        You should name all your documentation branches with the prefix `doc/` or `docs/`
+        as that will preempt triggering the full battery of continuous integration tests.
+
+1. **Make the changes you've discussed, following the [NiPreps coding style guide](#nipreps-coding-style-guide).**<br />
+  Try to keep the changes focused: it is generally easy to review changes that address one feature or bug at a time.
+  It can also be helpful to test your changes locally,
+  using a [NiPreps development environment][link_devel].
+  Once you are satisfied with your local changes, [add/commit/push them][link_add_commit_push]
+  to the branch on your forked repository.
+
+1. **Submit a [pull request][link_pullrequest].**<br />
+   A member of the development team will review your changes to confirm
+   that they can be merged into the main code base.<br />
+   Pull request titles should begin with a descriptive prefix
+   (for example, `ENH: Support for SB-reference in multi-band datasets`):
+     * `ENH`: enhancements or new features ([example][enh_ex])
+     * `FIX`: bug fixes ([example][fix_ex])
+     * `TST`: new or updated tests ([example][tst_ex])
+     * `DOC`: new or updated documentation ([example][doc_ex])
+     * `STY`: style changes ([example][sty_ex])
+     * `REF`: refactoring existing code ([example][ref_ex])
+     * `CI`: updates to continous integration infrastructure ([example][ci_ex])
+     * `MAINT`: general maintenance ([example][maint_ex])
+     * For works-in-progress, add the `WIP` tag in addition to the descriptive prefix.
+       Pull-requests tagged with `WIP:` will not be merged until the tag is removed.
+
+1. **Have your PR reviewed by the developers team, and update your changes accordingly in your branch.**<br />
+   The reviewers will take special care in assisting you address their comments, as well as dealing with conflicts
+   and other tricky situations that could emerge from distributed development.
+
+## NiPreps coding style guide
+
+Whenever possible, instances of Nipype `Node`s and `Workflow`s should use the same names
+as the variables they are assigned to.
+This makes it easier to relate the content of the working directory to the code
+that generated it when debugging.
+
+Workflow variables should end in `_wf` to indicate that they refer to Workflows
+and not Nodes.
+For instance, a workflow whose basename is `myworkflow` might be defined as
+follows:
+
+```Python
+from nipype.pipeline import engine as pe
+
+myworkflow_wf = pe.Workflow(name='myworkflow_wf')
+```
+
+If a workflow is generated by a function, the name of the function should take
+the form `init_<basename>_wf`:
+
+```Python
+def init_myworkflow_wf(name='myworkflow_wf):
+    workflow = pe.Workflow(name=name)
+    ...
+    return workflow
+
+myworkflow_wf = init_workflow_wf(name='myworkflow_wf')
+```
+
+If multiple instances of the same workflow might be instantiated in the same
+namespace, the workflow names and variables should include either a numeric
+identifier or a one-word description, such as:
+
+```Python
+myworkflow0_wf = init_workflow_wf(name='myworkflow0_wf')
+myworkflow1_wf = init_workflow_wf(name='myworkflow1_wf')
+
+# or
+
+myworkflow_lh_wf = init_workflow_wf(name='myworkflow_lh_wf')
+myworkflow_rh_wf = init_workflow_wf(name='myworkflow_rh_wf')
+```
+
+## Recognizing contributions
+
+We welcome and recognize all contributions regardless their size, content or scope:
+from documentation to testing and code development.
+You can see a list of current developers and contributors in our [zenodo file][link_zenodo].
+Before every release, a new [zenodo file][link_zenodo] will be generated.
+The [update script][link_update_script] will also sort creators and contributors by
+the relative size of their contributions, as provided by the `git-line-summary` utility
+distributed with the `git-extras` package.
+Last positions in both the *creators* and *contributors* list will be reserved to
+the project leaders.
+These special positions can be revised to add names by punctual request and revised for
+removal and update of ordering in an scheduled manner every two years.
+All the authors enlisted as *creators* participate in the revision of modifications.
+
+### Publications
+
+Anyone listed as a *developer* or a *contributor* can start the submission process of a manuscript
+as first author (please see [Membership](members.md), where these concepts are
+described).
+To compose the author list, all the *creators* MUST be included (except for those people who
+opt to drop-out) and all the *contributors* MUST be invited to participate.
+First authorship(s) is (are) reserved for the authors that originated and kept the initiative
+of submission and wrote the manuscript.
+To generate the ordering of your paper, please run ``python .maint/paper_author_list.py`` from the
+root of the repository, on the up-to-date ``upstream/master`` branch.
+Then, please modify this list and place your name first.
+All developers and contributors are pulled together in a unique list, and last authorships assigned.
+*NiPreps* and its community adheres to open science principles, such that a pre-print should
+be posted on an adequate archive service (e.g., [ArXiv](https://arxiv.org) or
+[BioRxiv](https://biorxiv.org)) prior publication.
+
+
+## Licensing
+
+*NiPreps* is licensed under the Apache 2.0 license.
+By contributing to *NiPreps*,
+you acknowledge that any contributions will be licensed under the same terms.
+
+## Thank you!
+
+You're awesome. :wave::smiley:
+
+<br>
+
+*&mdash; Based on contributing guidelines from the [STEMMRoleModels][link_stemmrolemodels] project.*
+
+[^1]: The imposter syndrome disclaimer was originally written by
+    [Adrienne Lowe](https://github.com/adriennefriend) for a
+    [PyCon talk](https://www.youtube.com/watch?v=6Uj746j9Heo), and was
+    adapted based on its use in the README file for the
+    [MetPy project](https://github.com/Unidata/MetPy).
+
+[link_github]: https://github.com/
+[link_fMRIPrep]: https://github.com/nipreps/fmriprep
+[link_signupinstructions]: https://help.github.com/articles/signing-up-for-a-new-github-account
+
+[link_neurostars]: https://neurostars.org/tags/fmriprep
+
+[link_git]: https://git-scm.com/
+[link_handbook]: https://guides.github.com/introduction/git-handbook/
+[link_swc_intro]: http://swcarpentry.github.io/git-novice/
+
+[writing_formatting_github]: https://help.github.com/articles/getting-started-with-writing-and-formatting-on-github
+[markdown]: https://daringfireball.net/projects/markdown
+[rick_roll]: https://www.youtube.com/watch?v=dQw4w9WgXcQ
+
+[link_issues]: https://github.com/nipreps/fmriprep/issues
+[link_labels]: https://github.com/nipreps/fmriprep/labels
+[link_discussingissues]: https://help.github.com/articles/discussing-projects-in-issues-and-pull-requests
+
+[link_bugs]: https://github.com/nipreps/fmriprep/labels/bug
+[link_firstissue]: https://github.com/nipreps/fmriprep/labels/good%20first%20issue
+[link_enhancement]: https://github.com/nipreps/fmriprep/labels/enhancement
+
+[link_pullrequest]: https://help.github.com/articles/creating-a-pull-request-from-a-fork
+[link_fork]: https://help.github.com/articles/fork-a-repo/
+[link_clone]: https://help.github.com/articles/cloning-a-repository
+[link_githubedit]: https://help.github.com/articles/editing-files-in-your-repository
+[link_texteditor]: https://en.wikipedia.org/wiki/Text_editor
+[link_vscode]: https://code.visualstudio.com/
+[link_addremote]: https://help.github.com/articles/configuring-a-remote-for-a-fork
+[link_pushpullblog]: https://www.igvita.com/2011/12/19/dont-push-your-pull-requests/
+[link_branches]: https://help.github.com/articles/creating-and-deleting-branches-within-your-repository/
+[link_add_commit_push]: https://help.github.com/articles/adding-a-file-to-a-repository-using-the-command-line
+[link_updateupstreamwiki]: https://help.github.com/articles/syncing-a-fork/
+[link_stemmrolemodels]: https://github.com/KirstieJane/STEMMRoleModels
+[link_zenodo]: https://github.com/nipreps/fmriprep/blob/master/.zenodo.json
+[link_update_script]: https://github.com/nipreps/fmriprep/blob/master/.maintenance/update_zenodo.py
+[link_devel]: https://fmriprep.readthedocs.io/en/latest/contributors.html
+[link_fmriprep]: http://fmriprep.org
+[link_bidsapps]: https://bids-apps.neuroimaging.io
+[link_mattermost]: https://mattermost.brainhack.org/brainhack/channels/fmriprep
+[link_aroma]: https://fmriprep.readthedocs.io/en/stable/workflows.html#ica-aroma
+
+[enh_ex]: https://github.com/nipreps/fmriprep/pull/1508
+[fix_ex]: https://github.com/nipreps/fmriprep/pull/1378
+[tst_ex]: https://github.com/nipreps/fmriprep/pull/1098
+[doc_ex]: https://github.com/nipreps/fmriprep/pull/1515
+[sty_ex]: https://github.com/nipreps/fmriprep/pull/675
+[ref_ex]: https://github.com/nipreps/fmriprep/pull/816
+[ci_ex]: https://github.com/nipreps/fmriprep/pull/1048
+[maint_ex]: https://github.com/nipreps/fmriprep/pull/1239

--- a/.github/SUPPORT.md
+++ b/.github/SUPPORT.md
@@ -20,7 +20,7 @@ The *NiPreps* framework is built on experimental research software, so it is ver
 It's definitely not your fault, do not give up!
 
 Before you go ahead and ask a question, we ask you to do some research on your end.
-Chances are that someone has gon thorugh the same or a similar issue, and the response is recorded somewhere.
+Chances are that someone has gone through the same or a similar issue, and the response is recorded somewhere.
 Where to check for answers (in order of priority):
 
   1. [NeuroStars][neurostars]: this is a forum for neuroscientists like StackOverflow for programmers.

--- a/.github/SUPPORT.md
+++ b/.github/SUPPORT.md
@@ -91,7 +91,7 @@ Here are some tips:
 
 [source]: https://github.com/remarkjs/.github/blob/9858b4b693d61337b6d5ab37d36304d2a4b0bf33/support.md
 
-[mattermost]: https://mattermost.brainhack.org/brainhack/
+[mattermost]: https://mattermost.brainhack.org/brainhack/channels/town-square
 
 [mattermost-dmriprep]: https://mattermost.brainhack.org/brainhack/channels/dmriprep
 

--- a/.github/SUPPORT.md
+++ b/.github/SUPPORT.md
@@ -1,0 +1,100 @@
+# Support
+
+This document describes how to get help with *NiPreps*.
+We want to start off by saying thank you for using *NiPreps*.
+This project is a labor of love, and we appreciate all of the users that share the problems they encounter using our tools, catch bugs, make performance improvements, and help with documentation.
+Every contribution is meaningful, so thank you for participating.
+Here are a few guidelines that we ask you to follow so we can successfully address your issue.
+
+
+## Before you start: the Code of Conduct
+
+> 👉 **Note**: before participating in our community, please read our
+> [code of conduct][coc].
+> By interacting with this repository, organization, or community you agree to
+> abide by its terms.
+
+## You've encountered a problem
+
+The *NiPreps* framework is built on experimental research software, so it is very likely that you will hit some snags before you get the ball rolling.
+It's definitely not your fault, do not give up!
+
+Before you go ahead and ask a question, we ask you to do some research on your end.
+Chances are that someone has gon thorugh the same or a similar issue, and the response is recorded somewhere.
+Where to check for answers (in order of priority):
+
+  1. [NeuroStars][neurostars]: this is a forum for neuroscientists like StackOverflow for programmers.
+  1. [Nipy Discourse][discourse]: this is a platform similar to NeuroStars, but we use it for public communication with the community and at the time of writing doesn't really have particular debugging information, but you can find interesting resources here.
+  1. [*NiPreps* general documentation][nipreps]: here we provide some advice regarding how to run containers, how to set up [*TemplateFlow*][templateflow], etc.
+  1. **The Project's documentation site**. Our projects usually have an FAQ (frequently asked questions) that are specific to the tool.
+  1. **The Project's issue tracker at GitHub**. You'll easily find the issue tracker with the URL `https://github.com/nipreps/<project>/issues` (do not forget to replace `<project>` with the actual project name -- e.g., [`https://github.com/nipreps/fmriprep/issues`][fmriprep-issues])
+  1. 
+
+## Asking quality questions
+
+General questions should go to [NeuroStars][neurostars].
+If you want to join our meetings or learn more about the community, you can head to [Nipy Discourse][discourse].
+If you think neither of those is the right place, you are probably facing a bug - please then head to the project's GitHub discussions or the issue tracker (e.g., [fMRIPrep discussions][chat] and [fMRIPrep issues][fmriprep-issues]).
+
+Help us help you!
+Spend time framing questions and add links and resources.
+Spending the extra time up front can help save everyone time in the long run.
+Here are some tips:
+
+*   [Validate your BIDS dataset][validator]
+*   [Talk to a duck][rubberduck]!
+*   Don’t fall for the [XY problem][xy]
+*   Try to define what you need help with:
+    *   Is there something in particular you want to do?
+    *   What problem are you encountering and what steps have you taken to try
+        and fix it?
+    *   Is there a concept you don’t understand?
+*   Make sure you provide us with sufficient level of detail to understand the issue and, if possible, recreate it in our own settings.
+    To do so, it is important that you provide details such as the exact command line you were running, the full log that the tool generated, data (if you can share them), visual reports, etc. An guide of potential questions is found [here](https://github.com/nipreps/fmriprep/issues/new?assignees=&labels=bug&template=bug_report.yml).
+*   The more time you put into asking your question, the better we can help you
+*   If you're still not sure where to begin, feel free to pop into [the Brainhack's mattermost][mattermost] and introduce yourself!
+    You'll find some channels for particular tools (e.g., [*#fMRIPrep*][mattermost-fmriprep], [*#dMRIPrep*][mattermost-dmriprep], [*#MRIQC*][mattermost-mriqc]) where you can post your questions, although it is not guaranteed that it will be revised any soon.
+    Please understand that we run this community on semi- or fully-volunteering basis, and sometimes our availability is very reduced.
+
+!!! note
+    Guidelines derived from [Titus Wormer][author]'s [`SUPPORT.md` file for RemarkJS][source]
+
+<!-- Definitions -->
+
+[license]: https://creativecommons.org/licenses/by/4.0/
+
+[author]: https://wooorm.com
+
+[coc]: https://www.nipreps.org/community/CODE_OF_CONDUCT/
+
+[rubberduck]: https://rubberduckdebugging.com
+
+[xy]: https://meta.stackexchange.com/questions/66377/what-is-the-xy-problem/66378#66378
+
+[cs]: https://codesandbox.io
+
+[contributing]: contributing.md
+
+[neurostars]: https://neurostars.org
+
+[discourse]: https://nipy.discourse.group/c/nipreps/9
+
+[nipreps]: https://nipreps.org
+
+[templateflow]: https://templateflow.org
+
+[fmriprep-issues]: https://github.com/nipreps/fmriprep/issues
+
+[fmriprep-discussions]: https://github.com/nipreps/fmriprep/discussions
+
+[validator]: http://bids-standard.github.io/bids-validator/
+
+[source]: https://github.com/remarkjs/.github/blob/9858b4b693d61337b6d5ab37d36304d2a4b0bf33/support.md
+
+[mattermost]: https://mattermost.brainhack.org/brainhack/
+
+[mattermost-dmriprep]: https://mattermost.brainhack.org/brainhack/channels/dmriprep
+
+[mattermost-fmriprep]: https://mattermost.brainhack.org/brainhack/channels/fmriprep
+
+[mattermost-mriqc]: https://mattermost.brainhack.org/brainhack/channels/MRIQC

--- a/.github/SUPPORT.md
+++ b/.github/SUPPORT.md
@@ -28,13 +28,16 @@ Where to check for answers (in order of priority):
   1. [*NiPreps* general documentation][nipreps]: here we provide some advice regarding how to run containers, how to set up [*TemplateFlow*][templateflow], etc.
   1. **The Project's documentation site**. Our projects usually have an FAQ (frequently asked questions) that are specific to the tool.
   1. **The Project's issue tracker at GitHub**. You'll easily find the issue tracker with the URL `https://github.com/nipreps/<project>/issues` (do not forget to replace `<project>` with the actual project name -- e.g., [`https://github.com/nipreps/fmriprep/issues`][fmriprep-issues])
-  1. 
+  1. If you're still not sure where to begin, feel free to pop into [the Brainhack's mattermost][mattermost] and introduce yourself!
+     You'll find some channels for particular tools (e.g., [*#fMRIPrep*][mattermost-fmriprep], [*#dMRIPrep*][mattermost-dmriprep], [*#MRIQC*][mattermost-mriqc]) where you can post your questions, although it is not guaranteed that it will be revised any time soon.
+
+Please understand that we run this community on semi- or fully-volunteering basis, and sometimes our availability is very reduced.
 
 ## Asking quality questions
 
 General questions should go to [NeuroStars][neurostars].
 If you want to join our meetings or learn more about the community, you can head to [Nipy Discourse][discourse].
-If you think neither of those is the right place, you are probably facing a bug - please then head to the project's GitHub discussions or the issue tracker (e.g., [fMRIPrep discussions][chat] and [fMRIPrep issues][fmriprep-issues]).
+If you think neither of those is the right place, you are probably facing a bug - please then head to the project's GitHub discussions or the issue tracker (e.g., [*fMRIPrep* discussions][chat] and [*fMRIPrep* issues][fmriprep-issues]).
 
 Help us help you!
 Spend time framing questions and add links and resources.
@@ -52,9 +55,6 @@ Here are some tips:
 *   Make sure you provide us with sufficient level of detail to understand the issue and, if possible, recreate it in our own settings.
     To do so, it is important that you provide details such as the exact command line you were running, the full log that the tool generated, data (if you can share them), visual reports, etc. An guide of potential questions is found [here](https://github.com/nipreps/fmriprep/issues/new?assignees=&labels=bug&template=bug_report.yml).
 *   The more time you put into asking your question, the better we can help you
-*   If you're still not sure where to begin, feel free to pop into [the Brainhack's mattermost][mattermost] and introduce yourself!
-    You'll find some channels for particular tools (e.g., [*#fMRIPrep*][mattermost-fmriprep], [*#dMRIPrep*][mattermost-dmriprep], [*#MRIQC*][mattermost-mriqc]) where you can post your questions, although it is not guaranteed that it will be revised any soon.
-    Please understand that we run this community on semi- or fully-volunteering basis, and sometimes our availability is very reduced.
 
 !!! note
     Guidelines derived from [Titus Wormer][author]'s [`SUPPORT.md` file for RemarkJS][source]

--- a/.github/SUPPORT.md
+++ b/.github/SUPPORT.md
@@ -37,7 +37,7 @@ Please understand that we run this community on semi- or fully-volunteering basi
 
 General questions should go to [NeuroStars][neurostars].
 If you want to join our meetings or learn more about the community, you can head to [Nipy Discourse][discourse].
-If you think neither of those is the right place, you are probably facing a bug - please then head to the project's GitHub discussions or the issue tracker (e.g., [*fMRIPrep* discussions][chat] and [*fMRIPrep* issues][fmriprep-issues]).
+If you think neither of those is the right place, you are probably facing a bug - please then head to the project's GitHub discussions or the issue tracker (e.g., [*fMRIPrep* discussions][fmriprep-discussions] and [*fMRIPrep* issues][fmriprep-issues]).
 
 Help us help you!
 Spend time framing questions and add links and resources.


### PR DESCRIPTION
Most of this PR just moves existing information over here. Changes:

1. The Code of Conduct is just updated to the version 2.0 of the original source, with minimal edits introduced in the original GitHub's MVG (minimally viable governance) project - which means, instead of Chris and myself, now the point of contact is the steering committee.
1. The `SUPPORT.md` file is new, probably the only piece that requires second eyes before accepting.