### PR TITLE
Fix: fix  typo in bug_report template

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -26,7 +26,7 @@ body:
   - type: input
     id: version
     attributes:
-      label: What version of fMRIPrep are you running?
+      label: What version of the software are you running?
     validations:
       required: true
   - type: dropdown


### PR DESCRIPTION
-Change "fmriprep" to the "software" in bug_report template.
-Solve nipreps/mriqc#1093.