### PR TITLE
MNT: Add dependabot config to auto-update actions

### DIFF
--- a/dependabot.yml
+++ b/dependabot.yml
@@ -1,0 +1,14 @@
+# Set update schedule for GitHub Actions
+
+version: 2
+updates:
+
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      # Check for updates to GitHub Actions every week
+      interval: "weekly"
+    groups:
+      actions-infrastructure:
+        patterns:
+          - "actions/*"

--- a/dependabot.yml
+++ b/dependabot.yml
@@ -12,3 +12,4 @@ updates:
       actions-infrastructure:
         patterns:
           - "actions/*"
+          - "codecov/*"


### PR DESCRIPTION
I think this should enable this for all repositories that do not have a custom dependabot config.